### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,9 @@ FROM ubuntu:20.04
 
 RUN apt-get -y update
 RUN apt-get -y upgrade
-RUN apt-get -y install clang curl gnupg
+RUN apt-get --no-install-recommends -y install ca-certificates clang curl gnupg
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
   && curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 RUN apt-get -y update
-RUN apt-get -y install bazel
-RUN apt-get -y install python3 python-is-python3 python3-distutils
+RUN apt-get --no-install-recommends -y install bazel python3 python-is-python3 python3-distutils
 RUN printf "startup --output_user_root=/tmp/bazel_output\n" > /root/.bazelrc


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>